### PR TITLE
Remove any format: from doc files

### DIFF
--- a/cli/how-to/create-run-fn.md
+++ b/cli/how-to/create-run-fn.md
@@ -20,7 +20,6 @@ name: nodefn
 version: 0.0.1
 runtime: node
 entrypoint: node func.js
-format: json
 ```
 
 For more information on possible value in the `func.yaml` file see **Link to funcfile doc**.
@@ -37,7 +36,6 @@ name: t1
 version: 1.0.1
 runtime: node
 entrypoint: node func.js
-format: json
 ```
 
 ## Create a `func.yaml` using an Existing Function File
@@ -52,7 +50,6 @@ name: t3
 version: 0.0.1
 runtime: node
 entrypoint: node func.js
-format: json
 ```
 
 

--- a/fn/operate/private_registries.md
+++ b/fn/operate/private_registries.md
@@ -47,14 +47,16 @@ c18ac6172e0d        registry:2          "/entrypoint.sh /e..."   2 seconds ago  
 
 Given a function called "dummy":
 
-```bash
+```sh
 $ ls ./dummy
 func.go    func.yaml
+```
+
+```sh
 $ cat ./dummy/func.yaml
 version: 0.0.1
 runtime: go
 entrypoint: ./func
-format: http
 ```
 
 Upload it to your registry (notice the use of `--registry`):


### PR DESCRIPTION
Cleaning up format: lines for examples. Just found a couple of files in this repo.
