### PR TITLE
fix: don''t run dind init script when without privileged

### DIFF
--- a/fn/operate/options.md
+++ b/fn/operate/options.md
@@ -75,7 +75,7 @@ There are some reasons you may not want to use dind, such as using the image cac
 One way is to mount the host Docker. Everything is essentially the same except you add a `-v` flag:
 
 ```sh
-docker run --rm --name functions -it -v /var/run/docker.sock:/var/run/docker.sock -v $PWD/data:/app/data --entrypoint /app/fnserver -p 8080:8080 fnproject/fnserver
+docker run --rm --name functions -it -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -v $PWD/data:/app/data --entrypoint /app/fnserver -p 8080:8080 fnproject/fnserver
 ```
 
 On Linux systems where SELinux is enabled and set to "Enforcing", SELinux will stop the container from accessing

--- a/fn/operate/options.md
+++ b/fn/operate/options.md
@@ -75,7 +75,7 @@ There are some reasons you may not want to use dind, such as using the image cac
 One way is to mount the host Docker. Everything is essentially the same except you add a `-v` flag:
 
 ```sh
-docker run --rm --name functions -it -v /var/run/docker.sock:/var/run/docker.sock -v $PWD/data:/app/data -p 8080:8080 fnproject/fnserver
+docker run --rm --name functions -it -v /var/run/docker.sock:/var/run/docker.sock -v $PWD/data:/app/data --entrypoint /app/fnserver -p 8080:8080 fnproject/fnserver
 ```
 
 On Linux systems where SELinux is enabled and set to "Enforcing", SELinux will stop the container from accessing


### PR DESCRIPTION
don't run dind docker-entrypoint.sh when without privileged, because it will throw some warning to request run with `--privileged` argument, but actually it don’t need.
reset the docker entrypoint to /app/fnserver is the fast way to fix this if you don't want to rebuild docker image