### PR TITLE
Removed simple usages of hot in the docs

### DIFF
--- a/fdks/fdk-java/FunctionConfiguration.md
+++ b/fdks/fdk-java/FunctionConfiguration.md
@@ -52,7 +52,7 @@ public class ConstructorConfig {
 
 In addition to using the constructor you can also annotate instance or static methods with  [@FnConfiguration](../api/src/main/java/com/fnproject/fn/api/FnConfiguration.java) to initialize your function object or class state.
 
-The configuration method will be called for you once per runtime (i.e. once for multiple invocations of a "hot function") so changes made within this method will apply to all invocations of your function.
+The configuration method will be called for you once per runtime (i.e. once for multiple invocations of a function) so changes made within this method will apply to all invocations of your function.
 
 This method must have a `void` return value and if your function method is static, the configuration method must also be static.
 

--- a/fdks/fdk-java/TestingFunctions.md
+++ b/fdks/fdk-java/TestingFunctions.md
@@ -73,7 +73,7 @@ The following sends an event with a simple string body to your function, and the
   }
 ```
 
-It is also possible to send multiple events and then check the pending responses. This simulates the behaviour of *hot functions*. With hot functions all enqueued events will be executed by the runtime before results can be checked; use `getResults()` to get a list of `FnResult` objects that describe the output.
+It is also possible to send multiple events and then check the pending responses. With functions all enqueued events will be executed by the runtime before results can be checked; use `getResults()` to get a list of `FnResult` objects that describe the output.
 
 ```java
   @Test

--- a/fdks/fdk-node/README.md
+++ b/fdks/fdk-node/README.md
@@ -1,7 +1,7 @@
 # Fn Function Developer Kit for Node.js
 
 This Function Developer Kit makes it easy to deploy Node.js functions to Fn.
-It currently supports default (cold) and hot functions using the JSON format.
+
 
 ## Creating a Node Function
 

--- a/fdks/fdk-python/README.md
+++ b/fdks/fdk-python/README.md
@@ -4,7 +4,7 @@ Purpose of this library to provide simple interface to parse HTTP 1.1 requests.
 
 Following examples are showing how to use API of this library to work with streaming HTTP requests from Fn service.
 
-## Handling Hot JSON Functions
+## Handling JSON Functions
 
 A main loop is supplied that can repeatedly call a user function with a series of HTTP requests.
 In order to utilise this, you can write your `func.py` as follows:

--- a/fn/general/introduction.md
+++ b/fn/general/introduction.md
@@ -58,7 +58,7 @@ When you deploy your function to an application on Fn server, the following happ
 That's it. When you call the function via the call command or `curl`, the container is executed and the results are returned to you.
 
 ### Fn FDKs Makes Function Development Easy
-The Fn platform has Function Development Kits (FDKs) which are a set of helper libraries that handle the system internals (protocols, parsing input and output, logic for hot function containers, etc.) automatically thereby making function development easier. Fn has FDKs for popular languages - Java, Node.js, Python, Go, and Ruby.
+The Fn platform has Function Development Kits (FDKs) which are a set of helper libraries that handle the system internals (protocols, parsing input and output, logic for function containers, etc.) automatically thereby making function development easier. Fn has FDKs for popular languages - Java, Node.js, Python, Go, and Ruby.
 
 ![Pictures of supported languages](images/fn-fdks.png)
 

--- a/fn/operate/logging.md
+++ b/fn/operate/logging.md
@@ -22,7 +22,7 @@ You may add a syslog url to any function application and all functions that
 exist under that application will ship all of their logs to it. You may
 provide a comma separated list, if desired. Currently, we support `tcp`,
 `udp`, and `tcp+tls`, and this will not work if behind a proxy [yet?] (this is
-my life now). This feature only works for 'hot' functions.
+my life now).
 
 An example syslog url is:
 

--- a/fn/operate/options.md
+++ b/fn/operate/options.md
@@ -47,7 +47,7 @@ docker run -e VAR_NAME_FILE=/path/to/secret ...
 | `FN_LOG_PREFIX` | If supplying a syslog url in `FN_LOG_DEST`, a prefix to add to each log line
 | `FN_API_CORS_ORIGINS` | A comma separated list of URLs to enable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) for (or `*` for all domains). This corresponds to the allowed origins in the `Acccess-Control-Allow-Origin` header.  | None |
 | `FN_API_CORS_HEADERS` | A comma separated list of Headers to enable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) for. This corresponds to the allowed headers in the `Access-Control-Allow-Headers` header.  | Origin,Content-Length,Content-Type |
-| `FN_FREEZE_IDLE_MSECS` | Set this option to specify the amount of time to wait in milliseconds before pausing/freezing an idle hot container. Set to 0 to freeze idle containers without any delay. Set to negative integer to disable freeze/pause of idle hot containers. | 50 |
+| `FN_FREEZE_IDLE_MSECS` | Set this option to specify the amount of time to wait in milliseconds before pausing/freezing an idle container. Set to 0 to freeze idle containers without any delay. Set to negative integer to disable freeze/pause of idle hot containers. | 50 |
 | `FN_EJECT_IDLE_MSECS` | Set this option to specify the amount of time in milliseconds for an idle hot container to become eligible for eviction if the system is starved for CPU and Memory resources. Set to negative integer to disable this feature. | 1000 |
 | `FN_MAX_RESPONSE_SIZE` | Set this option to specify the http body or json response size in bytes from the containers. | 0 (off) |
 | `DOCKER_HOST` | Docker remote API URL. | /var/run/docker.sock |


### PR DESCRIPTION
Removed almost all of the "hot" references in the guides. Only remaining reference is in ruby FDK which I plan on fixing. Text fix only.