### PR TITLE
Add troubleshooting and known issue section to docs

### DIFF
--- a/fn/troubleshoot/README.md
+++ b/fn/troubleshoot/README.md
@@ -1,0 +1,13 @@
+# Troubleshooting
+This page lists solutions to problems you might encounter with Fn.
+
+## Common Problems
+Here is a list of common problems you might encounter while using Fn.
+
+* [Can't create an application with Fn client](common/cannot-create-app.md)
+* [Can't deploy a function with Fn client](common/cannot-deploy-app.md)
+
+## Known Issues
+This is a list of known issues with Fn. The pages linked here provide detailed information about an issue. These pages are usually linked to a GitHub issue for a particular repo.
+
+* [Trying to invoke a function when using a CentOS based Linux fails with an error message](known-issues/2019-08-fn-invoke-fails.md)

--- a/fn/troubleshoot/common/cannot-create-app.md
+++ b/fn/troubleshoot/common/cannot-create-app.md
@@ -1,0 +1,21 @@
+# Cannot create application with Fn client
+
+### Error Messages
+`fn create app app-name` fails with error message.
+
+* "Fn: Post http://localhost:8080/v2/apps: dial tcp [::1]:8080: connect: connection refused"
+
+### Problem
+The most common causes of this error message is:
+
+* The fn server has not been started.
+* Another service is using port 8080.
+
+### Solution
+To solve this problem:
+
+* Start Fn server
+* If Fn server does not start
+    * Run `netstat -a` to see if there is a server on port 8080.
+    * Stop the other server.
+    * Start Fn server.

--- a/fn/troubleshoot/common/cannot-deploy-app.md
+++ b/fn/troubleshoot/common/cannot-deploy-app.md
@@ -1,0 +1,21 @@
+# Cannot Deploy a Function with Fn client
+
+### Error Messages
+`fn --verbose deploy --app app-name --local` fails with error message.
+
+* "Fn: Get http://localhost:8080/v2/apps?name=nodeapp: dial tcp [::1]:8080: connect: connection refused"
+
+### Problem
+The most common causes of this error message is:
+
+* The Fn server has not been started.
+* Another service is using port 8080.
+
+### Solution
+To solve this problem:
+
+* Start Fn server
+* If Fn server does not start
+    * Run `netstat -a` to see if there is a server on port 8080.
+    * Stop the other server.
+    * Start Fn server.

--- a/fn/troubleshoot/known-issues/2019-08-fn-invoke-fails.md
+++ b/fn/troubleshoot/known-issues/2019-08-fn-invoke-fails.md
@@ -1,0 +1,29 @@
+# `fn invoke` fails when using an a CentOS based Linux
+Date Reported: 7/2/19  Issue: <https://github.com/fnproject/fn/issues/1520>
+
+### Error messages
+* CentOS: "kernel memory accounting disabled in this runc build"
+* Oracle Linux: "API error (500): starting container process caused process_linux.go:402: container init caused process_linux.go:367: setting cgroup config for procHooks process caused kernel memory accounting disabled in this runc build: unknown" fn_id=01DHQC8C5YNG8G00GZJ0000002 idle_timeout=30 image="javafn:0.0.3" memory=128
+
+**Reproduced with:**
+
+* Docker:18.09(Git commit:e32a1bd)
+* Fn Server:0.3.728(latest)
+* Fn Client :0.5.84(latest)
+* Oracle Linux 7.x
+
+### Problem
+CentOS 7.x enables kernel memory limit by default even though it's a experimental feature(not sure why), and RunC uses this feature without checking. This is causing a problem with Docker.
+
+**See:**
+
+* [Fn Issue](https://github.com/fnproject/fn/issues/1520)
+* [Enabling kmem accounting can break applications on CentOS7 #1725](https://github.com/opencontainers/runc/issues/1725)
+* [cgroups documenation](https://lwn.net/Articles/529927/)
+
+### Workaround
+There seems to be three options:
+
+* Downgrade your system's containerd.io to containerd.io-1.2.2-3.3.el7 (a version not built with nokmem) and hope you don't run into the same issue.
+* Don't run Fn server on a CentOS based Linux kernel 3.x system.
+* Downgrade Docker to v18.0


### PR DESCRIPTION
Adding a section for troubleshooting and known issues. Covering "CentOS 7.x enables kernel memory limit by default" issue with Docker as a start. Please provide feedback if you would like to change something about the structure or format of the documents. Thanks.