### PR TITLE
Add link to QRCode example. Fix FDK for Java.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ If you are a developer using Fn, this section is for you. For operating Fn, see 
 * FDK for Java
     * [Configuration Variables](https://github.com/fnproject/docs/tree/master/fdks/fdk-java/examples/configuration-variables): Set configuration values for applications, function, and in `func.yaml`.
     * [Gradle Build](https://github.com/fnproject/docs/tree/master/fdks/fdk-java/examples/gradle-build): Use a function to build and run a Java app using Gradle.
+    * [QR Code](https://github.com/fnproject/docs/blob/master/fdks/fdk-java/examples/qr-code/README.md): Generate QR Codes from data passed to the function.
     * [Regex](https://github.com/fnproject/docs/tree/master/fdks/fdk-java/examples/regex-query): Pass a regex to a function.
     * [Simple Reverse String](https://github.com/fnproject/docs/tree/master/fdks/fdk-java/examples/string-reverse): Reverse the letters in a string.
 

--- a/fdks/fdk-java/DataBinding.md
+++ b/fdks/fdk-java/DataBinding.md
@@ -1,12 +1,12 @@
 # Data Binding for function input and output
-The Fn Java FDK provides some standard tools for handling binding input to your functions to Java objects and types - You can also configure your own data binding either per-function or publish function data  binding libraries, see [Extending Data Binding](ExtendingDataBinding.md) for details of how to do this.
+The Fn FDK for Java provides some standard tools for handling binding input to your functions to Java objects and types - You can also configure your own data binding either per-function or publish function data  binding libraries, see [Extending Data Binding](ExtendingDataBinding.md) for details of how to do this.
 
 
 ## Simple data binding
 
 Fn functions are invoked from a HTTP request whose body can provide input to the function.
 
-The Fn Java FDK includes functionality to convert the data provided in the body of the HTTP request into frequently used types directly.
+The Fn FDK for Java includes functionality to convert the data provided in the body of the HTTP request into frequently used types directly.
 
 Add a string parameter to your function to receive the HTTP body of the function call as a string and return a string value to set the body of the HTTP response:
 
@@ -108,7 +108,7 @@ public class TestFn {
 ```
 
 ## Working with raw function events
-To get the most flexibility in handling data in and out of your function, the FDK also provides an abstraction of the raw Fn Java FDK events received or returned by the function by means of the [InputEvent](../api/src/main/java/com/fnproject/fn/api/InputEvent.java) and [OutputEvent](../api/src/main/java/com/fnproject/fn/api/OutputEvent.java) interfaces.
+To get the most flexibility in handling data in and out of your function, the FDK also provides an abstraction of the raw Fn FDK for Java events received or returned by the function by means of the [InputEvent](../api/src/main/java/com/fnproject/fn/api/InputEvent.java) and [OutputEvent](../api/src/main/java/com/fnproject/fn/api/OutputEvent.java) interfaces.
 
 Using this approach allows you to:
 
@@ -116,7 +116,7 @@ Using this approach allows you to:
 - read the request body as an `InputStream`;
 - control content type (and other headers) and status of the response.
 
-The Fn Java FDK can automatically convert the input HTTP request into an `InputEvent` and provide it as the parameter of the function. Similarly, it can take the `OutputEvent` returned by the function and construct an appropriate HTTP response.
+The Fn FDK for Java can automatically convert the input HTTP request into an `InputEvent` and provide it as the parameter of the function. Similarly, it can take the `OutputEvent` returned by the function and construct an appropriate HTTP response.
 
 Below is a function that looks at both the body of the request and a custom `X-My-Header` header.
 
@@ -141,13 +141,13 @@ public class Events {
         String text = rawInput.consumeBody(this::readData);
 
         String responseBody = "Received '" + text + "' with my header '" + header + "'.\n";
-        
+
         Map<String, String> customHeaders = new HashMap<>();
         customHeaders.put("X-My-Response-Header", "any value here");
 
         OutputEvent out = OutputEvent.fromBytes(
             responseBody.getBytes(), // Data
-            OutputEvent.SUCCESS,     // Any numeric HTTP status code can be used here 
+            OutputEvent.SUCCESS,     // Any numeric HTTP status code can be used here
             "text/plain",            // Content type
             Headers.fromMap(customHeaders)  // and additional custom headers on output
         );

--- a/fdks/fdk-java/ExtendingDataBinding.md
+++ b/fdks/fdk-java/ExtendingDataBinding.md
@@ -5,7 +5,7 @@ By following this step-by-step guide you will learn to configure custom handling
 
 ## Overview
 
-In the [Data Binding](DataBinding.md) tutorial you have seen how the raw data received and returned by the function is represented by [InputEvent](../api/src/main/java/com.fnproject.fn/api/InputEvent.java)s and [OutputEvent](../api/src/main/java/com.fnproject.fn/api/OutputEvent.java)s. The Fn Java FDK provides out-of-the-box functionality to convert these to some simple types and POJOs, but you might want to customize the way your input and output data is marshalled from the HTTP request and to the HTTP response.
+In the [Data Binding](DataBinding.md) tutorial you have seen how the raw data received and returned by the function is represented by [InputEvent](../api/src/main/java/com.fnproject.fn/api/InputEvent.java)s and [OutputEvent](../api/src/main/java/com.fnproject.fn/api/OutputEvent.java)s. The Fn FDK for Java provides out-of-the-box functionality to convert these to some simple types and POJOs, but you might want to customize the way your input and output data is marshalled from the HTTP request and to the HTTP response.
 
 This is done through the *Coercion* abstractions.
 

--- a/fdks/fdk-java/FunctionConfiguration.md
+++ b/fdks/fdk-java/FunctionConfiguration.md
@@ -1,7 +1,7 @@
 # Function initialization and configuration
 
 Function objects and classes may be re-used for multiple function events in the same Java virtual machine depending on how your function is configured and how frequently it is called.
-The Fn Java FDK allows you to perform once-per-runtime initialization behaviour that allows you to create long-lived objects such as static data, and database connections that can be re-used across multiple function events.
+The Fn FDK for Java allows you to perform once-per-runtime initialization behavior that allows you to create long-lived objects such as static data, and database connections that can be re-used across multiple function events.
 
 You can set configuration values on your function's routes and the function app  using the Fn tool or in your `func.yaml`. This configuration can contain deployment-specific data which you do not want to store in your source code.
 

--- a/fdks/fdk-java/README.md
+++ b/fdks/fdk-java/README.md
@@ -1,7 +1,7 @@
 # Fn Java Functions Developer Kit - Docs and Examples
 [![CircleCI](https://circleci.com/gh/fnproject/fdk-java.svg?style=svg&circle-token=348bec5610c34421f6c436ab8f6a18e153cb1c01)](https://circleci.com/gh/fnproject/fdk-java)
 
-This page provides links to docs and examples on how to use the Java Functions Development Kit (Java FDK) to develop applications.
+This page provides links to docs and examples on how to use the Functions Development Kit for Java (FDK for Java) to develop applications.
 
 ## Docs
 * [Data Binding for function input and output](DataBinding.md)
@@ -12,21 +12,21 @@ This page provides links to docs and examples on how to use the Java Functions D
 * [Testing your functions](TestingFunctions.md)
 
 ## Examples
-* [String reverse](examples/string-reverse/README.md): This function takes a string and returns the reverse of the string. The Java FDK handles marshalling data into your
+* [String reverse](examples/string-reverse/README.md): This function takes a string and returns the reverse of the string. The FDK for Java handles marshalling data into your
 function without the function having any knowledge of the FDK API.
 * [Regex query](examples/regex-query/README.md): This function takes a JSON object containing a `text` field
 and a `regex` field and returns a JSON object with a list of matches in the `matches` field. It
 demonstrates the builtin JSON support of the Fn Java wrapper (provided through Jackson) and how the
 platform handles serialization of POJO return values.
 * [QR Code gen](examples/qr-code/README.md): This function parses the query parameters of a GET request (through the `InputEvent` passed into the function) to generate a QR code. It demonstrates
-the `InputEvent` and `OutputEvent` interfaces which provide low level access to data entering the Fn Java FDK.
+the `InputEvent` and `OutputEvent` interfaces which provide low level access to data entering the Fn FDK for Java.
 * [Asynchronous thumbnails generation](examples/async-thumbnails/README.md): This example showcases the Fn Flow asynchronous execution API, by creating a workflow that takes an image and asynchronously generates three thumbnails for it, then uploads them to an object storage.
-* [Gradle build](examples/gradle-build/README.md): This shows how to use Gradle to build functions using the Java FDK. 
+* [Gradle build](examples/gradle-build/README.md): This shows how to use Gradle to build functions using the FDK for Java.
 
-## Contribute to the Java FDK
-If wish to contribute to the Java FDK development see our [Contributing to Fn Guide](https://github.com/fnproject/fn/tree/master/docs#for-contributors).
+## Contribute to the FDK for Java
+If wish to contribute to the FDK for Java development see our [Contributing to Fn Guide](https://github.com/fnproject/fn/tree/master/docs#for-contributors).
 
-For details on the Java FDK Development see the [Java FDK Repo](https://github.com/fnproject/fdk-java).
+For details on the FDK for Java Development see the [FDK for Java Repo](https://github.com/fnproject/fdk-java).
 
 Before you get started you will need the following things:
 
@@ -58,7 +58,7 @@ func.yaml created
 
 This creates the boilerplate for a new Java Function based on Maven and Oracle
 Java 9. The `pom.xml` includes a dependency on the latest version of the Fn
-Java FDK that is useful for developing your Java functions.
+FDK for Java that is useful for developing your Java functions.
 
 You can now import this project into your favourite IDE as normal.
 
@@ -155,7 +155,7 @@ Hello, Universe!
 ```
 
 ### 4. Testing your function
-The Fn Java FDK includes a testing library providing useful [JUnit
+The Fn FDK for Java includes a testing library providing useful [JUnit
 4](http://junit.org/junit4/) rules to test functions. Look at the test in
 `src/test/java/com/example/fn/HelloFunctionTest.java`:
 
@@ -246,7 +246,7 @@ Hello, world!
 ```
 
 ### 6. Something more interesting
-The Fn Java FDK supports [flexible data binding](DataBinding.md)  to make
+The Fn FDK for Java supports [flexible data binding](DataBinding.md)  to make
 it easier for you to map function input and output data to Java objects.
 
 Below is an example to of a Function that returns a POJO which will be
@@ -297,9 +297,9 @@ $ echo -n Michael | fn run
 
 ## 7. Where do I go from here?
 
-Learn more about the Fn Java FDK by reading the next tutorials in the series.
+Learn more about the Fn FDK for Java by reading the next tutorials in the series.
 Also check out the examples in the [`examples` directory](examples) for some
-functions demonstrating different features of the Fn Java FDK.
+functions demonstrating different features of the Fn FDK for Java.
 
 ### Configuring your function
 

--- a/fdks/fdk-java/TestingFunctions.md
+++ b/fdks/fdk-java/TestingFunctions.md
@@ -1,6 +1,6 @@
 # Testing your functions
 
-The Fn Java FDK testing harness allows you to quickly build and test your Java functions in your IDE and test them in an emulated function runtime without uploading your functions to the cloud. The framework uses [JUnit 4](http://junit.org/junit4/) rules.
+The Fn FDK for Java testing harness allows you to quickly build and test your Java functions in your IDE and test them in an emulated function runtime without uploading your functions to the cloud. The framework uses [JUnit 4](http://junit.org/junit4/) rules.
 
 ## Add the test module to your project
 
@@ -155,9 +155,9 @@ You can test that this is all handled correctly as follows:
 
 # Testing Fn Flows
 
-You can use `FlowTesting` to test [Fn Flows](FnFlowsUserGuide.md) within your functions.  If flow stages are started by functions within `thenRun` then the testing rule will execute the stages of those flows locally, returning when all spawned flows are complete. 
+You can use `FlowTesting` to test [Fn Flows](FnFlowsUserGuide.md) within your functions.  If flow stages are started by functions within `thenRun` then the testing rule will execute the stages of those flows locally, returning when all spawned flows are complete.
 
-Start by importing the `flow-testing` library into your functino in `test` scope: 
+Start by importing the `flow-testing` library into your functino in `test` scope:
 
 ```xml
 <dependency>
@@ -168,11 +168,11 @@ Start by importing the `flow-testing` library into your functino in `test` scope
 </dependency>
 ```
 
-Then create a `FlowTesting` field in your test class, passing the `FnTesting` rule as a parameter: 
+Then create a `FlowTesting` field in your test class, passing the `FnTesting` rule as a parameter:
 
 ```java
-import com.fnproject.fn.testing.FnTestingRule; 
-import com.fnproject.fn.testing.flow.FlowTesting; 
+import com.fnproject.fn.testing.FnTestingRule;
+import com.fnproject.fn.testing.flow.FlowTesting;
 
 public class FunctionTest {
   @Rule
@@ -181,7 +181,7 @@ public class FunctionTest {
   private final FlowTesting flowTesting = FlowTesting.create(testing);
 ```
 
-`FlowTesting` supports  mocking  the behaviour of Fn functions invoked by the  `invokeFunction()` API within flows. 
+`FlowTesting` supports  mocking  the behaviour of Fn functions invoked by the  `invokeFunction()` API within flows.
 
 You can specify that the invocation a function returns a valid value (as a byte array):
 
@@ -234,13 +234,13 @@ The same mechanism can be used to integrate mocking frameworks like [Mockito](ht
 
 Flow stages may execute in parallel. If you have several `withAction` clauses accessing the same shared state, you must ensure that that access is thread-safe.
 
-# Sharing data between tests and your functions 
+# Sharing data between tests and your functions
 To ensure isolation of each function invocation and/or flow stage, and to simulate the behaviour of the
-real Fn platform (where each function invocation can potentially run in a different JVM), the `FnTestingRule` runs each `thenRun` invocation and each Flow stage using a different Java Class Loader. 
+real Fn platform (where each function invocation can potentially run in a different JVM), the `FnTestingRule` runs each `thenRun` invocation and each Flow stage using a different Java Class Loader.
 
-While this improves the veracity of tests, it prevents your tests from accessing or modifying the state of your functions and vice versa. 
+While this improves the veracity of tests, it prevents your tests from accessing or modifying the state of your functions and vice versa.
 
-If you need to share objects or static data between your test classes and your functions (e.g. to pre-initialize global state) you can do so within your tests using the `addSharedClass` (for a specific class) and `addSharedPrefix` (for a package, or class prefix) methods on `FnTestingRule`. 
+If you need to share objects or static data between your test classes and your functions (e.g. to pre-initialize global state) you can do so within your tests using the `addSharedClass` (for a specific class) and `addSharedPrefix` (for a package, or class prefix) methods on `FnTestingRule`.
 
 ```java
     testing.addSharedClass(MyClassWithStaticState.class); // Shares only the specific class
@@ -248,4 +248,4 @@ If you need to share objects or static data between your test classes and your f
     testing.addSharedPrefix("com.example.mysubpackage."); // Shares anything under a package
 ```
 
-While it is possible, it is not generally correct to share the function class itself with the test Class Loader - doing so may result in unexpected (not representative of the real fn platform) initialisation of static fields on the class. With Flows sharing the test class may also result in concurrent access to static data (via `@FnConfiguration` methods). 
+While it is possible, it is not generally correct to share the function class itself with the test Class Loader - doing so may result in unexpected (not representative of the real fn platform) initialisation of static fields on the class. With Flows sharing the test class may also result in concurrent access to static data (via `@FnConfiguration` methods).

--- a/fdks/fdk-java/examples/async-thumbnails/README.md
+++ b/fdks/fdk-java/examples/async-thumbnails/README.md
@@ -1,4 +1,4 @@
-# Example Fn Java FDK / Fn Flows Project: Asynchronous Thumbnails
+# Example Fn FDK for Java / Fn Flows Project: Asynchronous Thumbnails
 
 This example provides an HTTP endpoint for asynchronously creating three
 thumbnails of an image whose data is provided as the body of the HTTP request
@@ -47,7 +47,7 @@ docker container, so that you can verify when the thumbnails are uploaded.
 Build the function locally:
 
 ```bash
-$ fn deploy --local --app myapp 
+$ fn deploy --local --app myapp
 ```
 
 
@@ -110,7 +110,7 @@ public class ThumbnailsFunction {
                 .orElseThrow(() -> new RuntimeException("Missing configuration: OBJECT_STORAGE_ACCESS"));
         storageSecretKey = ctx.getConfigurationByKey("OBJECT_STORAGE_SECRET")
                 .orElseThrow(() -> new RuntimeException("Missing configuration: OBJECT_STORAGE_SECRET"));
-        
+
         resize128ID = ctx.getConfigurationByKey("RESIZE_128_FN_ID")
                   .orElseThrow(() -> new RuntimeException("Missing configuration: RESIZE_128_FN_ID"));
         resize256ID = ctx.getConfigurationByKey("RESIZE_256_FN_ID")
@@ -311,14 +311,14 @@ public class ThumbnailsFunctionTest {
           .setConfig("RESIZE_128_FN_ID","myapp/resize128")
           .setConfig("RESIZE_256_FN_ID","myapp/resize256")
           .setConfig("RESIZE_512_FN_ID","myapp/resize512");
-        
+
         flow.givenFn("myapp/resize128")
                 .withResult("128".getBytes())
             .givenFn("myapp/resize256")
                 .withResult("256".getBytes())
             .givenFn("myapp/resize512")
                 .withFunctionError();
-        
+
         fn.givenEvent()
              .withBody("testing".getBytes())
              .enqueue();

--- a/fdks/fdk-java/examples/gradle-build/README.md
+++ b/fdks/fdk-java/examples/gradle-build/README.md
@@ -1,4 +1,4 @@
-# Example Java Functions: Fn Gradle + Java fdk  
+# Example Java Functions: Fn Gradle + FDK for Java  
 
 This example shows you how to build a Java function by using a Dockerfile.
 
@@ -6,7 +6,7 @@ This example shows you how to build a Java function by using a Dockerfile.
 ## Key points:
 
 * [Dockerfile](Dockerfile) - contains the containerized Docker build (based on dockerhub library/gradle images) and image build - this includes the gradle invocation
-* The `cacheDeps` task in `build.gradle` pulls down dependencies into the container gradle cache to speed up docker builds. 
+* The `cacheDeps` task in `build.gradle` pulls down dependencies into the container gradle cache to speed up docker builds.
 * The `copyDeps` task in `build.gradle` copies the functions compile deps.
 * This uses JDK 11 by default
 
@@ -32,10 +32,8 @@ $ fn create app gradle-build-app
 fn deploy --app gradle-build-app --local
 ```
 
-(4) Invoke the function 
+(4) Invoke the function
 
 ```sh
 fn invoke gradle-build-app gradle_build
 ```
-
- 

--- a/fdks/fdk-java/examples/qr-code/README.md
+++ b/fdks/fdk-java/examples/qr-code/README.md
@@ -104,7 +104,7 @@ application or the function.
 
 ### Testing
 
-The fn Java FDK provides a `com.fnproject.fn.testing` package for simulating
+The Fn FDK for Java provides a `com.fnproject.fn.testing` package for simulating
 function invocations and inspecting function results. This is accomplished
 by a fake functions server, `FnTesting`, whose life cycle is managed by a [JUnit rule](
 https://github.com/junit-team/junit4/wiki/rules).

--- a/fdks/fdk-java/examples/string-reverse/README.md
+++ b/fdks/fdk-java/examples/string-reverse/README.md
@@ -10,8 +10,8 @@ dlroW olleH
 
 ## Demonstrated FDK features
 
-This example uses **none** of the Fn Java FDK features, in fact it doesn't have
-any dependency on the Java FDK.  It is just plain old Java code.
+This example uses **none** of the Fn FDK for Java features, in fact it doesn't
+have any dependency on the FDK for Java.  It is just plain old Java code.
 
 ## Step by step
 
@@ -68,9 +68,7 @@ public class StringReverse {
 ```
 
 As you can see, this is plain Java with no references to the Fn API. The
-Fn Java FDK handles the marshalling of the HTTP body into the `str`
+Fn FDK for Java handles the marshalling of the HTTP body into the `str`
 parameter as well as the marshalling of the returned reversed string into the HTTP
 response body (see [Data Binding](../../DataBinding.md) for more
 information on how marshalling is performed).
-
-

--- a/fn/general/faq.md
+++ b/fn/general/faq.md
@@ -26,7 +26,7 @@ The Fn Project is an evolution of the IronFunctions project from Iron.io and our
 
 * **Container Native:** Containers fundamentally change the way we package software. Our goal for the Fn Project is to abstract out the complexities of containers, even create a “containerless experience”, but expose the power of containers to those who have adopted containers as their packaging format. That is why `fn deploy` can abstract the whole process away from you, but we also support native Docker containers as Functions. This party is optionally BYOD: Bring your own Dockerfile.
 
-* **Programming Model:** The cost, operational benefits, and hype, of serverless has created a rush to adopt, and this has led to many fantastic use cases including ops tooling, event-driven architectures, triggers in the cloud, etc., but there are still technology gaps preventing more complex serverless app design utilizing native language features, true IDE integration, testing, workflow, etc. We want to address this, starting with the release of the Java FDK and Fn Flow as initial blueprints.
+* **Programming Model:** The cost, operational benefits, and hype, of serverless has created a rush to adopt, and this has led to many fantastic use cases including ops tooling, event-driven architectures, triggers in the cloud, etc., but there are still technology gaps preventing more complex serverless app design utilizing native language features, true IDE integration, testing, workflow, etc. We want to address this, starting with the release of the FDK for Java and Fn Flow as initial blueprints.
 
 * **Orchestrator Agnostic:** Kubernetes is great, and deployments of Fn can benefit from it handling all the lower level infrastructure, but it’s not the only game in town, nor do we want end users of Fn having to learn or deal with Kubernetes. A clear separation of serverless and container orchestration is important, thus allowing the project to adapt and evolve in an ever-changing cloud landscape.
 
@@ -172,7 +172,7 @@ State management is not part of Fn but you can use any storage service or databa
 
 The problem you face is the lack of a guarantee of which instance of a function is called.  Standard practice is to externalize state.
 
-If your need for stateful functions is motivated by managing steps of a workflow that spans several functions (or several calls to the same function), check out [Fn Flow](https://github.com/fnproject/flow). 
+If your need for stateful functions is motivated by managing steps of a workflow that spans several functions (or several calls to the same function), check out [Fn Flow](https://github.com/fnproject/flow).
 
 ### Can functions write to a non-persistent location?
 


### PR DESCRIPTION
Add link to Java QRCode example. Changes all "Java FDK" instances to "FDK for Java". All FDKs will be named "FDK for Blah" from now on.