### PR TITLE
Added tip for setting DEBUG log-level

### DIFF
--- a/fn/troubleshoot/README.md
+++ b/fn/troubleshoot/README.md
@@ -15,4 +15,5 @@ This is a list of known issues with Fn. The pages linked here provide detailed i
 ## Debug
 Learn how to get detailed information about what is happening in the Fn server.
 
-* [Debug](debug.md)
+* [Debug HTTP Headers with the Fn CLI](debug-headers.md)
+* [Enable DEBUG log-level on the Fn Server](debug-loglevel.md)

--- a/fn/troubleshoot/README.md
+++ b/fn/troubleshoot/README.md
@@ -1,6 +1,12 @@
 # Troubleshooting
 This page lists solutions to problems you might encounter with Fn. If you want to learn more about troubleshooting, see [Troubleshooting and Logging with Fn](https://github.com/fnproject/tutorials/tree/master/Troubleshooting/README.md).
 
+## Debug
+Learn how to get detailed information about what is happening in the Fn server.
+
+* [Enable DEBUG log-level on the Fn Server](debug-loglevel.md)
+* [Debug HTTP Headers with the Fn CLI](debug-headers.md)
+
 ## Common Problems
 Here is a list of common problems you might encounter while using Fn.
 
@@ -11,9 +17,3 @@ Here is a list of common problems you might encounter while using Fn.
 This is a list of known issues with Fn. The pages linked here provide detailed information about an issue. These pages are usually linked to a GitHub issue for a particular repo.
 
 * [Trying to invoke a function when using a CentOS based Linux fails with an error message](known-issues/2019-08-fn-invoke-fails.md)
-
-## Debug
-Learn how to get detailed information about what is happening in the Fn server.
-
-* [Debug HTTP Headers with the Fn CLI](debug-headers.md)
-* [Enable DEBUG log-level on the Fn Server](debug-loglevel.md)

--- a/fn/troubleshoot/debug-headers.md
+++ b/fn/troubleshoot/debug-headers.md
@@ -1,4 +1,4 @@
-# DEBUG=1
+# Use DEBUG=1 for Client Commands
 
 If you're interacting with functions via the `fn` CLI, you can enable debug
 mode to see the full details of the HTTP requests going to the Fn server and
@@ -37,4 +37,3 @@ tutorial	01DQ2STN6KNG8G00GZJ000001Q
 
 All debug output is written to stderr while the normal response is written
 to stdout so it's easy to capture or pipe either for processing.
-

--- a/fn/troubleshoot/debug-loglevel.md
+++ b/fn/troubleshoot/debug-loglevel.md
@@ -1,0 +1,25 @@
+# Log to Fn Server Terminal Window with DEBUG
+When working with Fn locally, you have the option to turn on the DEBUG log-level using the `fn start` command. This causes detailed information about functions to be output to the terminal after Fn server is started.
+
+To enable DEBUG logging for Fn server, restart the server with the following command:
+
+![user input](images/userinput.png)
+>```sh
+> fn start --log-level DEBUG
+>```
+
+```sh
+2019/12/19 09:26:27 ¡¡¡ 'fn start' should NOT be used for PRODUCTION !!! see https://github.com/fnproject/fn-helm/
+time="2019-12-19T16:26:28Z" level=info msg="Setting log level to" fields.level=DEBUG
+...
+```
+Notice in the first couple of messages state that the log level is set to DEBUG.
+
+Here is an example of the kind of output generated when a Runtime Exception is encountered with Java.
+```sh
+time="2019-12-19T16:27:55Z" level=debug msg="Caused by: java.lang.RuntimeException: Something went horribly wrong! ...\n" action="server.handleFnInvokeCall)-fm" app_id=01DWFFR290NG8G00GZJ0000001 call_id=01DWFFS7QZNG8G00GZJ0000003 fn_id=01DWFFRQVQNG8G00GZJ0000002 image="fndemouser/trouble:0.0.2" user_log=true
+time="2019-12-19T16:27:55Z" level=debug msg="    at com.example.fn.HelloFunction.handleRequest(HelloFunction.java:7)\n" action="server.handleFnInvokeCall)-fm" app_id=01DWFFR290NG8G00GZJ0000001 call_id=01DWFFS7QZNG8G00GZJ0000003 fn_id=01DWFFRQVQNG8G00GZJ0000002 image="fndemouser/trouble:0.0.2" user_log=true
+```
+A Runtime Exception was thrown on line 7 of the HelloFunction.
+
+Running the Fn server with the DEBUG log level is a great way to track down any issues you are having with your functions.


### PR DESCRIPTION
Adding this log overdue page to the troubleshooting sections. Main README.md links to the Tutorial on the same subject.