### PR TITLE
docs(operate): Fix Windows `docker run` command.

### DIFF
--- a/fn/operate/windows.md
+++ b/fn/operate/windows.md
@@ -3,7 +3,7 @@
 Windows doesn't support Docker in Docker so you'll change the run command to the following:
 
 ```sh
-docker run --privileged --rm --name functions -it -v /var/run/docker.sock:/var/run/docker.sock -v ${pwd}/data:/app/data -p 8080:8080 fnproject/fnserver
+docker run --privileged --rm --name functions -it -v /var/run/docker.sock:/var/run/docker.sock -v ./data:/app/data -p 8080:8080 fnproject/fnserver
 ```
 
 Then everything should work as normal.


### PR DESCRIPTION
The previous `${pwd}` syntax gave error:

```
docker: Error response from daemon: create ${pwd}/data: "${pwd}/data" includes invalid characters 
for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
```