### PR TITLE
fix `Mount the Host Docker` command

### DIFF
--- a/fn/operate/options.md
+++ b/fn/operate/options.md
@@ -75,7 +75,17 @@ There are some reasons you may not want to use dind, such as using the image cac
 One way is to mount the host Docker. Everything is essentially the same except you add a `-v` flag:
 
 ```sh
-docker run --rm --name functions -it -v /var/run/docker.sock:/var/run/docker.sock -v $PWD/data:/app/data -p 8080:8080 fnproject/fnserver
+docker run \
+  --rm \
+  --name functions \
+  -it \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v $PWD/data:/app/data \
+  -v $PWD/data/iofs:/iofs \
+  -e "FN_IOFS_DOCKER_PATH=$PWD/data/iofs" \
+  -e "FN_IOFS_PATH=/iofs" \
+  -p 80:8080 \
+  fnproject/fnserver
 ```
 
 On Linux systems where SELinux is enabled and set to "Enforcing", SELinux will stop the container from accessing


### PR DESCRIPTION
Current Behaviour: FnServer starts but when you invoke a Function, it throws an error `Error invoking function. status: 502 message: Container failed to initialize...`

Reason: The above command is missing 3 args (1 -v and 2 -e)

Fix: Add the missing args and test that 1) FnServer is starting successfully and 2) Functions are getting invoked successfully

Extra: Changed host port from 8080 to 80 to be in sync with the above command