### PR TITLE
Fix document link for HTTPGatewayFunctions.md

### DIFF
--- a/fdks/fdk-java/README.md
+++ b/fdks/fdk-java/README.md
@@ -7,7 +7,7 @@ This page provides links to docs and examples on how to use the Function Develop
 * [Data Binding for function input and output](DataBinding.md)
 * [Extending the data binding functionality](ExtendingDataBinding.md)
 * [Function initialization and configuration](FunctionConfiguration.md)
-* [Accessing HTTP information From functions](HTTPGatewayFunction.md)
+* [Accessing HTTP information From functions](HTTPGatewayFunctions.md)
 * [Spring cloud functions with Fn](SpringCloudFunctionSupport.md)
 * [Testing your functions](TestingFunctions.md)
 


### PR DESCRIPTION
Hi, I've fixed a documentation problem about a link for https://github.com/fnproject/docs/blob/master/fdks/fdk-java/HTTPGatewayFunctions.md.
Sincerely could you please check it.
