### PR TITLE
Update Swagger link in Developer Docs

### DIFF
--- a/fn/develop/README.md
+++ b/fn/develop/README.md
@@ -22,7 +22,7 @@ If you are a developer using Fn through the API, this section is for you.
 
 ### Advanced
 
-* [API Reference](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/fnproject/fn/master/docs/swagger.yml)
+* [API Reference](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/fnproject/fn/master/docs/swagger_v2.yml)
 * [API Clients](clients.md)
 * [CLI Source](https://github.com/fnproject/cli/)
 * [Packaging functions](packaging.md)


### PR DESCRIPTION
The Swagger Link in the Developer docs was pointing to a (now) non-existent file. This PR updates it to point to the correct swagger file.