### PR TITLE
05.23 Update CSharp(C#) references.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Fn is an event-driven, open source, [Functions-as-a-Service (FaaS)](https://gith
     * [Function Debugging](fn/troubleshoot/debug-loglevel.md)
     * [FAQ](fn/general/faq.md)
 * Using Fn with Other Languages
-    * [Using Fn with C# (Community Supported)](https://fnproject.io/tutorials/csharp/intro/)
+    * [Using Fn with C#](https://fnproject.io/tutorials/csharp/intro/)
     * [Using Fn with Go](https://fnproject.io/tutorials/Introduction/)
     * [Using Fn with Ruby](https://fnproject.io/tutorials/ruby/intro/)
 * Exploring Fn

--- a/fn/develop/fdks.md
+++ b/fn/develop/fdks.md
@@ -7,7 +7,8 @@ Using the `fn init` CLI command will produce a boilerplate function along with t
 The Fn team has chosen a set of FDKs to initially support, while other FDKs will be labeled as "experimental".
 
 ## Officially Supported FDKs
-
+    
+* [C#](https://fnproject.io/tutorials/csharp/intro/)
 * [Go](https://github.com/fnproject/docs/tree/master/fdks/fdk-go)
 * [Java](https://github.com/fnproject/docs/blob/master/fdks/fdk-java/README.md)
 * [Python](https://github.com/fnproject/docs/blob/master/fdks/fdk-python/README.md)


### PR DESCRIPTION
Update the C# references to point to the new official FDK version. Leaving a pointer to the community version on the FDKs page.