### PR TITLE
docs(cli): update command reference for OCI parity and usability enhancements

### DIFF
--- a/cli/ref/fn-create-app.md
+++ b/cli/ref/fn-create-app.md
@@ -18,8 +18,43 @@ COMMAND OPTIONS
   --config value      Application configuration
   --annotation value  Application annotations
   --syslog-url value  Syslog URL to send application logs to
+  --subnet-id value   Subnet OCID (repeatable for multiple subnets)
+  --tag value         Freeform tag in key=value format (repeatable)
+  --defined-tag value Defined tag in namespace.key=value format (repeatable)
+  --network-security-group-ids value  OCI NSG OCID (repeatable)
+  --trace-config value OCI trace config JSON or file:// path
+  --image-policy-config value OCI image policy config JSON or file:// path
+  --security-attributes value OCI security attributes JSON or file:// path
+  --from-json value    Structured JSON input for command parameters
+  --wait-for-state value         Wait until resource reaches lifecycle state
+  --max-wait-seconds value       Max waiter duration in seconds
+  --wait-interval-seconds value  Waiter poll interval in seconds
   
 ```
 
-[Some link](#)
+## Examples
+
+Create an app with subnet and tags:
+
+```bash
+fn create app my-app \
+  --subnet-id ocid1.subnet.oc1..aaaa \
+  --tag Department=Finance \
+  --defined-tag Operations.CostCenter=42
+```
+
+Create an app with advanced OCI parity options:
+
+```bash
+fn create app parity-app \
+  --subnet-id ocid1.subnet.oc1..aaaa \
+  --network-security-group-ids ocid1.networksecuritygroup.oc1..aaaa \
+  --trace-config '{"isEnabled":true,"domainId":"ocid1.apmdomain.oc1..aaaa"}'
+```
+
+Create from JSON input:
+
+```bash
+fn create app json-app --from-json file:///absolute/path/app-create.json
+```
 

--- a/cli/ref/fn-create-function.md
+++ b/cli/ref/fn-create-function.md
@@ -19,8 +19,52 @@ COMMAND OPTIONS
   --idle-timeout value      Function idle timeout (eg. 30) (default: 0)
   --annotation value        Function annotation (can be specified multiple times)
   --image value             Function image
+  --provisioned-concurrency value  Provisioned concurrency (none | constant:<count>)
+  --detached-timeout value         Detached invocation timeout (e.g. 20m, 1h)
+  --on-success value               Success destination shorthand (<stream|queue|notifications>:<ocid>)
+  --on-failure value               Failure destination shorthand (<stream|queue|notifications>:<ocid>)
+  --tag value                      Freeform tag in key=value format (repeatable)
+  --defined-tag value              Defined tag in namespace.key=value format (repeatable)
+  --pbf value                      Pre-Built Function listing OCID source
+  --trace-config value             OCI trace config JSON or file:// path
+  --timeout-in-seconds value       OCI parity timeout option in seconds
+  --detached-mode-timeout-in-seconds value  OCI parity detached timeout in seconds
+  --success-destination value      OCI parity destination JSON or file:// path
+  --failure-destination value      OCI parity destination JSON or file:// path
+  --from-json value                Structured JSON input for command parameters
+  --wait-for-state value           Wait until resource reaches lifecycle state
+  --max-wait-seconds value         Max waiter duration in seconds
+  --wait-interval-seconds value    Waiter poll interval in seconds
   
 ```
 
-[Some link](#)
+## Examples
+
+Create function with provisioned concurrency:
+
+```bash
+fn create function my-app my-fn myrepo/myimg:0.0.1 \
+  --provisioned-concurrency constant:40
+```
+
+Create long-running function with destinations:
+
+```bash
+fn create function my-app my-detached-fn myrepo/myimg:0.0.1 \
+  --detached-timeout 20m \
+  --on-success stream:ocid1.stream.oc1..aaaa \
+  --on-failure notifications:ocid1.onstopic.oc1..aaaa
+```
+
+Create function from PBF:
+
+```bash
+fn create function my-app my-pbf-fn --pbf ocid1.pbflisting.oc1..aaaa
+```
+
+Create function from JSON input:
+
+```bash
+fn create function my-app my-json-fn --from-json file:///absolute/path/fn-create.json
+```
 

--- a/cli/ref/fn-init.md
+++ b/cli/ref/fn-init.md
@@ -27,8 +27,36 @@ COMMAND OPTIONS
   --timeout value                Function timeout (eg. 30) (default: 0)
   --idle-timeout value           Function idle timeout (eg. 30) (default: 0)
   --annotation value             Function annotation (can be specified multiple times)
+  --tag value                    Freeform tag in key=value form (repeatable)
+  --defined-tag value            Defined tag in namespace.key=value form (repeatable)
+  --provisioned-concurrency value  Provisioned concurrency (none | constant:<count>)
+  --detached-timeout value       Detached invocation timeout (e.g. 20m, 1h)
+  --on-success value             Success destination shorthand (<stream|queue|notifications>:<ocid>)
+  --on-failure value             Failure destination shorthand (<stream|queue|notifications>:<ocid>)
+  --pbf value                    Initialize function from a Pre-Built Function listing OCID
   
 ```
 
-[Some link](#)
+## Examples
+
+Initialize with provisioned concurrency:
+
+```bash
+fn init --runtime go hello-pc --provisioned-concurrency constant:5
+```
+
+Initialize with long-running settings:
+
+```bash
+fn init --runtime java hello-long \
+  --detached-timeout 20m \
+  --on-success stream:ocid1.stream.oc1..aaaa \
+  --on-failure notifications:ocid1.onstopic.oc1..aaaa
+```
+
+Initialize from PBF:
+
+```bash
+fn init --name hello-pbf --pbf ocid1.pbflisting.oc1..aaaa
+```
 

--- a/cli/ref/fn-invoke.md
+++ b/cli/ref/fn-invoke.md
@@ -13,12 +13,33 @@ DESCRIPTION
   This command invokes a function. Users may send input to their function by passing input to this command via STDIN.
     
 COMMAND OPTIONS
-  --endpoint value      Specify the function invoke endpoint for this function, the app-name and func-name parameters will be ignored
-  --content-type value  The payload Content-Type for the function invocation.
-  --display-call-id     whether display call ID or not
-  --output value        Output format (json)
+  --endpoint value        Specify the function invoke endpoint for this function, the app-name and func-name parameters will be ignored
+  --content-type value    The payload Content-Type for the function invocation.
+  --display-call-id       whether display call ID or not
+  --output value          Output format (json)
+  --fn-intent value       Optional intent header for function invocation, e.g. httprequest or cloudevent
+  --is-dry-run            Send invocation as a dry run without executing the function
+  --fn-invoke-type value  Invoke type for Oracle Functions: sync or detached
   
 ```
 
-[Some link](#)
+## Examples
+
+Invoke in detached mode (subcommand):
+
+```bash
+fn invoke detached my-app my-fn --display-call-id
+```
+
+Invoke with OCI parity detached flag:
+
+```bash
+fn invoke my-app my-fn --fn-invoke-type detached --display-call-id
+```
+
+Invoke dry-run with intent:
+
+```bash
+fn invoke my-app my-fn --is-dry-run --fn-intent cloudevent
+```
 

--- a/cli/ref/fn-list-apps.md
+++ b/cli/ref/fn-list-apps.md
@@ -13,11 +13,35 @@ DESCRIPTION
   This command provides a list of defined applications.
     
 COMMAND OPTIONS
-  --cursor value  Pagination cursor
-  -n value        Number of apps to return (default: 100)
-  --output value  Output format (json)
+  --cursor value           Pagination cursor
+  -n value                 Number of apps to return (default: 100)
+  --output value           Output format (json)
+  --from-json value        Structured JSON input for command parameters
+  --display-name value     Filter applications by exact display name
+  --id value               Filter applications by OCID
+  --lifecycle-state value  Filter applications by lifecycle state
+  --sort-by value          Sort applications by supported field
+  --sort-order value       Sort order for list results
   
 ```
 
-[Some link](#)
+## Examples
+
+List apps filtered by display name:
+
+```bash
+fn list apps --display-name parity-app
+```
+
+List apps with sorting:
+
+```bash
+fn list apps --sort-by displayName --sort-order ASC
+```
+
+List apps from JSON input:
+
+```bash
+fn list apps --from-json '{"displayName":"parity-app","sortBy":"displayName","sortOrder":"ASC"}'
+```
 

--- a/cli/ref/fn-list.md
+++ b/cli/ref/fn-list.md
@@ -17,6 +17,7 @@ SUBCOMMANDS
   config, config, cf           List configurations for apps and functions
   contexts, context, ctx       List contexts
   functions, funcs, f, fn      List functions for an application
+  pbfs                         List Pre-Built Function listings and related resources
   triggers, trigs, t, tr       List all triggers
   help, h                      Shows a list of commands or help for one command
                            

--- a/cli/ref/fn-update-app.md
+++ b/cli/ref/fn-update-app.md
@@ -13,11 +13,51 @@ DESCRIPTION
   This command updates a created application.
     
 COMMAND OPTIONS
-  --config value, -c value  Application configuration
-  --annotation value        Application annotations
-  --syslog-url value        Syslog URL to send application logs to
+  --config value, -c value          Application configuration
+  --annotation value                Application annotations
+  --tag value                       Freeform tag in key=value form (repeatable)
+  --defined-tag value               Defined tag in namespace.key=value form (repeatable)
+  --remove-tag value                Remove a freeform tag by key (repeatable)
+  --remove-defined-tag value        Remove a defined tag by namespace.key (repeatable)
+  --clear-tags                      Clear all freeform and defined tags
+  --clear-freeform-tags             Clear all freeform tags
+  --clear-defined-tags              Clear all defined tags
+  --syslog-url value                Syslog URL to send application logs to
+  --subnet-id value                 Subnet OCID (accepted for non-Oracle providers; Oracle-backed update currently not supported)
+  --from-json value                 Structured JSON input for command parameters
+  --if-match value                  Apply optimistic concurrency control using the provided etag
+  --wait-for-state value            Wait until resource reaches lifecycle state
+  --max-wait-seconds value          Max waiter duration in seconds
+  --wait-interval-seconds value     Waiter poll interval in seconds
+  --network-security-group-ids value  OCI NSG OCID (repeatable)
+  --trace-config value              OCI trace config JSON or file:// path
+  --image-policy-config value       OCI image policy config JSON or file:// path
+  --security-attributes value       OCI security attributes JSON or file:// path
   
 ```
 
-[Some link](#)
+## Examples
+
+Update app tags:
+
+```bash
+fn update app my-app \
+  --tag Team=Payments \
+  --remove-tag Department \
+  --clear-defined-tags
+```
+
+Update advanced OCI app settings:
+
+```bash
+fn update app parity-app \
+  --image-policy-config file:///absolute/path/image-policy.json \
+  --security-attributes '{"oracle-zpr":{"MaxEgressCount":{"value":"42","mode":"enforce"}}}'
+```
+
+Update from JSON:
+
+```bash
+fn update app my-app --from-json file:///absolute/path/app-create.json
+```
 

--- a/cli/ref/fn-update-function.md
+++ b/cli/ref/fn-update-function.md
@@ -13,14 +13,65 @@ DESCRIPTION
   This command updates a function in an application.
     
 COMMAND OPTIONS
-  --memory value, -m value  Memory in MiB (default: 0)
-  --config value, -c value  Function configuration
-  --timeout value           Function timeout (eg. 30) (default: 0)
-  --idle-timeout value      Function idle timeout (eg. 30) (default: 0)
-  --annotation value        Function annotation (can be specified multiple times)
-  --image value             Function image
+  --memory value, -m value            Memory in MiB (default: 0)
+  --config value, -c value            Function configuration
+  --timeout value                     Function timeout (eg. 30) (default: 0)
+  --idle-timeout value                Function idle timeout (eg. 30) (default: 0)
+  --annotation value                  Function annotation (can be specified multiple times)
+  --image value                       Function image
+  --tag value                         Freeform tag in key=value form (repeatable)
+  --defined-tag value                 Defined tag in namespace.key=value form (repeatable)
+  --remove-tag value                  Remove a freeform tag by key (repeatable)
+  --remove-defined-tag value          Remove a defined tag by namespace.key (repeatable)
+  --clear-tags                        Clear all freeform and defined tags
+  --clear-freeform-tags               Clear all freeform tags
+  --clear-defined-tags                Clear all defined tags
+  --provisioned-concurrency value     Provisioned concurrency (none | constant:<count>)
+  --detached-timeout value            Detached invocation timeout (e.g. 20m, 1h)
+  --on-success value                  Success destination shorthand (<stream|queue|notifications>:<ocid>)
+  --on-failure value                  Failure destination shorthand (<stream|queue|notifications>:<ocid>)
+  --clear-on-success                  Clear detached success destination
+  --clear-on-failure                  Clear detached failure destination
+  --pbf value                         Pre-Built Function listing OCID source
+  --from-json value                   Structured JSON input for command parameters
+  --if-match value                    Apply optimistic concurrency control using the provided etag
+  --wait-for-state value              Wait until resource reaches lifecycle state
+  --max-wait-seconds value            Max waiter duration in seconds
+  --wait-interval-seconds value       Waiter poll interval in seconds
+  --trace-config value                OCI trace config JSON or file:// path
+  --timeout-in-seconds value          OCI parity timeout option in seconds
+  --detached-mode-timeout-in-seconds value  OCI parity detached timeout in seconds
+  --success-destination value         OCI parity destination JSON or file:// path
+  --failure-destination value         OCI parity destination JSON or file:// path
   
 ```
 
-[Some link](#)
+## Examples
+
+Update provisioned concurrency:
+
+```bash
+fn update function my-app my-fn --provisioned-concurrency constant:10
+```
+
+Update long-running settings:
+
+```bash
+fn update function my-app my-fn \
+  --detached-timeout 1h \
+  --on-success stream:ocid1.stream.oc1..aaaa \
+  --on-failure notifications:ocid1.onstopic.oc1..aaaa
+```
+
+Clear long-running destinations:
+
+```bash
+fn update function my-app my-fn --clear-on-success --clear-on-failure
+```
+
+Update from JSON:
+
+```bash
+fn update function my-app my-fn --from-json file:///absolute/path/fn-create.json
+```
 


### PR DESCRIPTION
cli/ref updates for create/update app, create/update function, init, invoke, list apps, and list functions
Highlights: provisioned concurrency, long-running flags/destinations, invoke parity flags, subnet/tag UX flags, PBF, advanced OCI parity flags, and --from-json examples.
The change is to update the fn CLI guide - https://github.com/fnproject/docs/tree/master/cli
